### PR TITLE
Moved the metadata into setup.cfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: python
+dist: focal
 python:
   - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
+  - "3.9"
 # command to install dependencies
 install:
+  - pip install --upgrade setuptools packaging wheel
   - pip install -r dev_requirements.txt
 # command to run tests
 script:
+  - python3 setup.py bdist_wheel
+  - pip3 install --upgrade ./dist/*.whl
   - pytest --cov=./ --flake8
-  - python3 setup.py sdist bdist_wheel
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
@@ -18,6 +22,7 @@ jobs:
     - name: "Numpy 1.15/SciPy 1.0"
       python: "3.6"
       install:
+        - pip install --upgrade setuptools packaging wheel
         - sed -i 's/~=/==/g' requirements.txt
         - pip install -r dev_requirements.txt
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install -r dev_requirements.txt
 # command to run tests
 script:
-  - python3 setup.py bdist_wheel
+  - python3 setup.py sdist bdist_wheel
   - pip3 install --upgrade ./dist/*.whl
   - pytest --cov=./ --flake8
 after_success:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,4 +2,5 @@ pytest~=5.4
 flake8~=3.8
 pytest-flake8~=1.0
 pytest-cov~=2.10
+setuptools_scm
 -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=44", "wheel", "setuptools_scm[toml]>=3.4.3"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/release.py
+++ b/release.py
@@ -2,6 +2,7 @@ import re
 import subprocess
 import sys
 from copy import copy
+from setuptools_scm import get_version
 
 import os.path
 
@@ -60,7 +61,6 @@ def matches_start(string: str, pattern: str):
 
 
 def get_current_version():
-    from setuptools_scm import get_version
 
     def vsch(x):
         return x.tag.base_version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = pyhank
+author = Edward Rogers
+author_email = etfrogers@hotmail.com
+description = pyhank - Quasi-discrete Hankel transforms for python
+url = https://github.com/etfrogers/pyhank
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+
+[options]
+packages = pyhank
+# exclusion via setup.cfg is broken currently, see https://github.com/pypa/setuptools/issues/2688
+install_requires = numpy~=1.15; scipy~=1.0
+python_requires = ~=3.6
+setup_requires = setuptools>=44; wheel; setuptools_scm[toml]>=3.4.3

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,4 @@
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setuptools.setup(
-    name="pyhank",
-    version="2.3.0",
-    author="Edward Rogers",
-    author_email="etfrogers@hotmail.com",
-    description="pyhank - Quasi-discrete Hankel transforms for python",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/etfrogers/pyhank",
-    packages=setuptools.find_packages(),
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-    python_requires='~=3.6',
-    install_requires=[
-        'numpy~=1.15',
-        'scipy~=1.0',
-    ]
-)
+if __name__ == "__main__":
+    setuptools.setup()

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import pytest
 
-from release import matches_start, Version
+from release import matches_start, Version, get_current_version
 
 
 def test_matches_start():
@@ -19,6 +19,11 @@ def test_matches_start():
 @pytest.mark.parametrize('string', ['67.0.2', '0.0.0', '1.2.0'])
 def test_string_round_trip(string: str):
     assert str(Version.from_string(string)) == string
+
+
+def test_get_current_version():
+    # just check it runs: we can't assert anything as the version will always change!
+    _ = get_current_version()
 
 
 @pytest.mark.parametrize('string', ['67.0.2', '0.0.0', '1.2.0'])


### PR DESCRIPTION
Moved the metadata into setup.cfg
The version is now stored purely in git tags. (I have done some minimal editing of the release script, but in fact we can throw away all the version-related machinery and reuse setuptools_scm one. I leave that up to you, if you want).
Added pyproject.toml .