### PR TITLE
Spherical Hankel transform

### DIFF
--- a/pyhank/hankel.py
+++ b/pyhank/hankel.py
@@ -14,8 +14,8 @@ class HankelTransform:
         :attr:`.HankelTransform.v` (frequency space) or equivalently :attr:`.HankelTransform.kr`
         (angular frequency or wavenumber space).
 
-        The constructor has one required argument (``order``). The remaining four arguments offer
-        three different ways of specifying the radial (and therefore implicitly the frequency) points:
+        The constructor has one required argument (``order``). The remaining five arguments offer
+        three different ways of specifying the radial (and therefore implicitly the frequency) points and type of Bessel functions:
 
         1. Supply both a maximum radius ``r_max`` and number of transform points ``n_points``
         2. Supply the original (often equally spaced) ``radial_grid`` on which you have currently
@@ -32,6 +32,9 @@ class HankelTransform:
            As in option 2, :attr:`.HankelTransform.n_points` is determined by ``k_grid.size``.
            :attr:`HankelTransform.r_max` is determined in a more complex way from ``np.max(k_grid)``.
 
+        By setting the argument ``bessel_type`` to either ``"polar"`` od ``"spherical"`` it is possible
+        to choose between :math:`J_n` and :math:`j_n` Bessel functions (default is ``"polar"``).
+
         :parameter order: Transform order :math:`p`
         :type order: :class:`int`
         :parameter max_radius: (Optional) Radial extent of transform :math:`r_\textrm{max}`
@@ -44,6 +47,8 @@ class HankelTransform:
         :type radial_grid: :class:`numpy.ndarray`
         :parameter k_grid: (Optional) Number of sample points :math:`N`
         :type k_grid: :class:`numpy.ndarray`
+        :parameter bessel_type: (Optional) Type of Bessel functions used to compute the transform
+        :type bessel_type: :class:`str`
 
         :ivar alpha: The first :math:`N` Roots of the :math:`p` th order Bessel function.
         :ivar alpha_n1: (N+1)th root :math:`\alpha_{N1}`

--- a/pyhank/one_shot.py
+++ b/pyhank/one_shot.py
@@ -5,7 +5,7 @@ import numpy as np
 from pyhank import HankelTransform
 
 
-def qdht(r: np.ndarray, f: np.ndarray, order: int = 0, axis: int = -2) -> Tuple[np.ndarray, np.ndarray]:
+def qdht(r: np.ndarray, f: np.ndarray, order: int = 0, axis: int = -2, bessel_type: str = "polar") -> Tuple[np.ndarray, np.ndarray]:
     """Perform a quasi-discrete Hankel transform of the function ``f`` (sampled at points
     ``r``) and return the transformed function and its sample points in :math:`k`-space.
 
@@ -29,13 +29,13 @@ def qdht(r: np.ndarray, f: np.ndarray, order: int = 0, axis: int = -2) -> Tuple[
     :return: A tuple containing the k coordinates of the transformed function and its values
     :rtype: (:class:`numpy.ndarray`, :class:`numpy.ndarray`)
     """
-    transformer = HankelTransform(order=order, radial_grid=r)
+    transformer = HankelTransform(order=order, radial_grid=r,  bessel_type=bessel_type)
     f_transform = transformer.to_transform_r(f, axis=axis)
     ht = transformer.qdht(f_transform, axis=axis)
     return transformer.kr, ht
 
 
-def iqdht(k: np.ndarray, f: np.ndarray, order: int = 0, axis: int = -2) -> Tuple[np.ndarray, np.ndarray]:
+def iqdht(k: np.ndarray, f: np.ndarray, order: int = 0, axis: int = -2, bessel_type: str = "polar") -> Tuple[np.ndarray, np.ndarray]:
     """Perform a inverse quasi-discrete Hankel transform of the function ``f`` (sampled at points
     ``k``) and return the transformed function and its sample points in radial space.
 
@@ -59,7 +59,7 @@ def iqdht(k: np.ndarray, f: np.ndarray, order: int = 0, axis: int = -2) -> Tuple
     :return: A tuple containing the radial coordinates of the transformed function and its values
     :rtype: (:class:`numpy.ndarray`, :class:`numpy.ndarray`)
     """
-    transformer = HankelTransform(order=order, k_grid=k)
+    transformer = HankelTransform(order=order, k_grid=k, bessel_type=bessel_type)
     f_transform = transformer.to_transform_k(f, axis=axis)
     ht = transformer.iqdht(f_transform, axis=axis)
     return transformer.r, ht

--- a/tests/test_hankel.py
+++ b/tests/test_hankel.py
@@ -430,3 +430,19 @@ def test_sinc(p):
                                    v < gamma*0.75)
     assert np.all(dynamical_error < -10)
     assert np.all(dynamical_error[not_near_gamma] < -35)
+
+# test spherical Hankel transform
+def test_spherical():
+    # This test checks whether Laplacian of a Gaussian is calculated correctly
+    r = np.linspace(0,10,100)
+    function = np.exp(-r**2/2)
+    analytical_laplacian = np.exp(-r**2/2)*(r**2-3)
+
+    transformer = HankelTransform(order=0, radial_grid=r, bessel_type="spherical")
+    laplacian = transformer.to_transform_r(function)
+    laplacian = transformer.qdht(laplacian)
+    laplacian = -laplacian * transformer.kr**2
+    laplacian = transformer.iqdht(laplacian)
+    laplacian = transformer.to_original_r(laplacian)
+
+    assert np.allclose(analytical_laplacian, laplacian, rtol=00.1, atol=0.001)


### PR DESCRIPTION
I extended the functionality of QDHT to use spherical Bessel functions. The user can switch between the modes by setting the `bessel_type` argument in the constructor to either `"polar"` (old) or `"spherical"` (new code). I couldn't find a similar Python module for spherical Hankel transform so I figured I could add it here.